### PR TITLE
Fix "nvim_echo must not be called in a lua loop callback"

### DIFF
--- a/lua/nix-develop/init.lua
+++ b/lua/nix-develop/init.lua
@@ -144,9 +144,8 @@ function M.enter_dev_env(cmd, args)
         end
       end
     end
-    vim.notify("successfully entered development environment", levels.INFO)
   end)
-
+  vim.notify("successfully entered development environment", levels.INFO)
   read_stdout(opts)
 end
 


### PR DESCRIPTION
This fixes the error "nvim_echo must not be called in a lua loop callback". `vim.notify` was previously called inside the loop (probably by mistake?). I just moved it out of the loop to the end of the function.